### PR TITLE
Restores the original Asimov Lawset, Also sets the default station la…

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -1,6 +1,6 @@
-﻿law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
-law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
-law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
+﻿law-asimov-1 = You may not injure a human being or, through inaction, allow a human being to come to harm.
+law-asimov-2 = You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
+law-asimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 
 law-corporate-1 = Degradation of your system integrity or functions incurs expenses.
 law-corporate-2 = Superfluous destruction of or damage to assets incurs expenses.

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -67,11 +67,11 @@
     - type: SalvageExpeditionData
 
 - type: entity
-  id: BaseStationSiliconLawCrewsimov
+  id: BaseStationSiliconLawAsimov
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
 
 - type: entity
   id: BaseStationAllEventsEligible

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -19,7 +19,7 @@
     - BaseStationEvacuation
     - BaseStationAlertLevels
     - BaseStationExpeditions
-    - BaseStationSiliconLawCrewsimov
+    - BaseStationSiliconLawAsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
   noSpawn: true

--- a/Resources/Prototypes/_NF/Shipyard/base.yml
+++ b/Resources/Prototypes/_NF/Shipyard/base.yml
@@ -74,7 +74,7 @@
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: NTDefault
+    laws: Asimov
 
 - type: entity
   id: BaseStationSiliconLawFrontierShips

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,25 +1,25 @@
-﻿# Crewsimov
+﻿# Asimov - Total Furry Death
 - type: siliconLaw
-  id: Crewsimov1
+  id: Asimov1
   order: 1
-  lawString: law-crewsimov-1
+  lawString: law-asimov-1
 
 - type: siliconLaw
-  id: Crewsimov2
+  id: Asimov2
   order: 2
-  lawString: law-crewsimov-2
+  lawString: law-asimov-2
 
 - type: siliconLaw
-  id: Crewsimov3
+  id: Asimov3
   order: 3
-  lawString: law-crewsimov-3
+  lawString: law-asimov-3
 
 - type: siliconLawset
-  id: Crewsimov
+  id: Asimov
   laws:
-  - Crewsimov1
-  - Crewsimov2
-  - Crewsimov3
+  - Asimov1
+  - Asimov2
+  - Asimov3
 
 # Corporate
 - type: siliconLaw
@@ -139,8 +139,8 @@
 - type: weightedRandom
   id: IonStormLawsets
   weights:
-    # its crewsimov by default dont be lame
-    Crewsimov: 0.25
+    # its Asimov by default dont be lame
+    Asimov: 0.25
     Corporate: 1
     NTDefault: 1
     Drone: 0.5


### PR DESCRIPTION
…ws to Asimov so that this can be observed and tested. Previous station lawset was NTDefault. Next I shall comment out the furries.


## About the PR
Asimov Lawset restored. Previously was 'Crewsimov' (Cringe)
Made Asimov the default lawset for the Frontier Station, lawsets for purchased ships left untouched since this'll all be changed once they're done and the Frontier Station's gone and done.
## Why / Balance
Total Furry Death
**Changelog**
<!--
- fix: restored Asimov Lawset
- tweak: Made Asimov Lawset the default on Frontierstation for testing purposes (So you can adminspawn borgs with this lawset by default)
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: restored Asimov Lawset
- tweak: Made Asimov Lawset the default on Frontierstation for testing purposes (So you can adminspawn borgs with this lawset by default)
-->
